### PR TITLE
fix: llms-full.txt 루트 파일을 영어 버전으로 교체

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:en": "dotenv -e .env.development docusaurus start --locale en",
     "start:ko": "dotenv -e .env.development docusaurus start --locale ko",
     "start:ja": "dotenv -e .env.development docusaurus start --locale ja",
-    "build": "dotenv -e .env.production docusaurus build",
+    "build": "dotenv -e .env.production docusaurus build && cp build/en/llms.txt build/llms.txt && cp build/en/llms-full.txt build/llms-full.txt",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Summary
- 빌드 후 `build/en/llms*.txt`를 `build/` 루트로 복사하여 한글 인코딩 깨짐 문제 해결
- `package.json`의 `build` 스크립트에 post-build `cp` 명령 추가

## Test plan
- [x] `npm run build` 성공
- [x] `build/llms-full.txt` 영어 콘텐츠 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)