### PR TITLE
docs: SDK v1.2.0 문서 리팩토링 및 i18n 동기화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,21 @@ docs/
 
 ### 다국어(i18n) 처리
 
-- **문서 콘텐츠**: `docs/`의 MDX 파일에 `<Tabs>`와 locale 분기로 언어별 콘텐츠를 하나의 파일에서 처리
+- **문서 콘텐츠**: `docs/`의 MDX 파일이 소스(한국어)이며, `i18n/en/`, `i18n/ja/` 디렉토리에 각 로케일 번역 파일이 위치
 - **UI 문자열**: `i18n/{ko,en,ja}/code.json`에 번역 키-값 저장
 - **데이터 테이블**: `src/data/setup.js`, `src/data/usage.js`에서 locale별 파라미터 설명을 객체로 관리
+
+### i18n 동기화 체크리스트
+
+`docs/` 소스(한국어) 수정 시 아래 체크리스트를 반드시 확인한다:
+
+- [ ] `i18n/en/docusaurus-plugin-content-docs/current/` 영어 번역 파일 동기화
+- [ ] `i18n/ja/docusaurus-plugin-content-docs/current/` 일본어 번역 파일 동기화
+- [ ] `src/data/setup.js` — `ko`, `en`, `ja` 3개 로케일 데이터 동기화
+- [ ] `src/data/usage.js` — `ko`, `en`, `ja` 3개 로케일 데이터 동기화
+- [ ] Mermaid 다이어그램 — 소스와 번역 파일의 flowchart/sequenceDiagram 구조 일치
+- [ ] Admonition 문법 — `:::tip`, `:::caution`, `:::info` 등이 `\:::` 이스케이프 없이 정상 표기
+- [ ] `npm run build` 후 `build/en/llms-full.txt`에 신규/수정 콘텐츠 포함 확인
 
 ### 홈페이지 구조
 

--- a/docs/03-usage/02-sdk-method.mdx
+++ b/docs/03-usage/02-sdk-method.mdx
@@ -257,30 +257,6 @@ const App = () => {
 export default App;
 ```
 
-### `KlleonChat.wakeUpAvatar()`
-
-유휴(idle) 상태의 아바타를 다시 활성화합니다. 장시간 대기 등으로 아바타가 비활성 상태에 진입했을 때 사용합니다.
-
-**사용 예시:**
-
-```tsx title="App.tsx (wakeUpAvatar)"
-const App = () => {
-  const handleWakeUp = () => {
-    window.KlleonChat.wakeUpAvatar();
-  };
-
-  return (
-    <div>
-      <avatar-container />
-      <chat-container />
-      <button onClick={handleWakeUp}>아바타 깨우기</button>
-    </div>
-  );
-};
-
-export default App;
-```
-
 ## 에코 기능
 
 ### `KlleonChat.echo(text)`

--- a/docs/04-guides/typescript-support.mdx
+++ b/docs/04-guides/typescript-support.mdx
@@ -60,7 +60,6 @@ enum ResponseChatType {
   START_LONG_WAIT = "START_LONG_WAIT",
   USER_SPEECH_STARTED = "USER_SPEECH_STARTED",
   USER_SPEECH_STOPPED = "USER_SPEECH_STOPPED",
-  RATE_LIMIT = "RATE_LIMIT",
   ACTIVATE_VOICE = "ACTIVATE_VOICE",
 }
 
@@ -110,7 +109,6 @@ export interface KlleonChat {
   changeAvatar: (option: ChangeAvatarOption) => Promise<void>;
   clearMessageList: () => void;
   stopSpeech: () => void;
-  wakeUpAvatar: () => void;
 }
 
 // 전역 window 객체에 KlleonChat 타입 선언

--- a/i18n/en/docusaurus-plugin-content-docs/current/02-setup/getting-started.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/02-setup/getting-started.mdx
@@ -62,13 +62,13 @@ You can install the Klleon Chat SDK by adding a `<script>` tag to your HTML file
 </html>
 ```
 
-\:::tip SDK Version
-Replace `{VERSION}` with the actual version number in `X.Y.Z` format (e.g., `1.0.0`). You can find the latest version via Klleon Studio or official announcements.
-\:::
+:::tip SDK Version
+Replace `{VERSION}` with the actual version number in `X.Y.Z` format (e.g., `1.0.0`). You can find the latest version via Klleon Studio or official announcements. Using the latest version is recommended, but you can specify a particular version if needed.
+:::
 
 ## SDK Initialization
 
-After the SDK is loaded, initialize it using `window.KlleonChat.init()`. Initialization typically happens after the DOM is ready, usually inside your main app script.
+After the SDK is loaded, initialize it using `window.KlleonChat.init()`. Initialization typically happens after the DOM is ready, usually inside your main app script. The two required options are `sdk_key` and `avatar_id`. It is recommended to register event listeners before calling `init`.
 
 ```tsx title="App.tsx (React)"
 import { useEffect } from "react";
@@ -78,19 +78,31 @@ function App() {
     const { KlleonChat } = window;
 
     const init = async () => {
+      // 1. Register status event listener
       KlleonChat.onStatusEvent((status) => {
+        // See 'Usage > Event Handling' for detailed Status values and meanings.
         if (status === "VIDEO_CAN_PLAY") {
           console.log("Avatar video ready!");
         }
       });
 
+      // 2. Register chat event listener
       KlleonChat.onChatEvent((chatData) => {
+        // See 'Usage > Event Handling' for ChatData structure and chat_type details.
         console.log("SDK Chat Event:", chatData);
       });
 
+      // 3. Initialize SDK
       await KlleonChat.init({
         sdk_key: "YOUR_SDK_KEY",
         avatar_id: "YOUR_AVATAR_ID",
+        // custom_id: "YOUR_CUSTOM_ID",
+        // user_key: "YOUR_USER_KEY",
+        // voice_code: "en_us",
+        // subtitle_code: "en_us",
+        // voice_tts_speech_speed: 1,
+        // enable_microphone: true,
+        // log_level: "debug",
       });
     };
     init();
@@ -108,9 +120,9 @@ The `init()` method accepts various configuration options:
 
 <Table columns={setup.en.initOptionColumns} data={setup.en.initOptionData} />
 
-\:::tip About `user_key`
+:::tip About `user_key`
 The `user_key` is managed through the End-User API. Contact `partnership@klleon.io` for access and usage instructions.
-\:::
+:::
 
 ## Full Working Example
 
@@ -123,8 +135,8 @@ Here’s a complete working example showing SDK installation, event handling, an
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS + TailwindCSS</title>
-    <script src="https://web.sdk.klleon.io/1.0.0/klleon-chat.umd.js"></script>
+    <title>Vite + React</title>
+    <script src="https://web.sdk.klleon.io/{VERSION}/klleon-chat.umd.js"></script>
   </head>
   <body>
     <div id="root"></div>
@@ -155,16 +167,21 @@ function App() {
     const { KlleonChat } = window;
 
     const init = async () => {
+      // 1. Register status event listener
       KlleonChat.onStatusEvent((status) => {
+        // See 'Usage > Event Handling' for detailed Status values and meanings.
         if (status === "VIDEO_CAN_PLAY") {
           console.log("Avatar video ready!");
         }
       });
 
+      // 2. Register chat event listener
       KlleonChat.onChatEvent((chatData) => {
+        // See 'Usage > Event Handling' for ChatData structure and chat_type details.
         console.log("SDK Chat Event:", chatData);
       });
 
+      // 3. Initialize SDK
       await KlleonChat.init({
         sdk_key: "YOUR_SDK_KEY",
         avatar_id: "YOUR_AVATAR_ID",

--- a/i18n/en/docusaurus-plugin-content-docs/current/03-usage/02-sdk-method.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/03-usage/02-sdk-method.mdx
@@ -22,37 +22,39 @@ import Head from "@docusaurus/Head";
 
 # SDK Methods
 
-Klleon Chat SDK provides essential methods for building interactive web-based avatar communication experiences. From initialization to avatar control, this guide walks through core functionalities you can integrate into your application.
+Klleon Chat SDK provides a variety of methods for interactive communication within your web application. This guide covers core functionalities from SDK initialization to message sending and avatar control.
 
 ## SDK Lifecycle
 
-Managing the SDK's lifecycle properly helps prevent memory leaks and ensures stable application behavior.
+Properly managing the SDK's lifecycle is crucial for preventing resource leaks and ensuring application stability.
 
 ### `KlleonChat.init(options)`
 
-Initializes the SDK and connects to the server. Should be called once during the app’s startup.
+Initializes the SDK and prepares the connection to the server. This method should be called once when the application loads.
 
-**Initialization Options:**
+**Initialization Options (`options`):**
 
 <Table columns={setup.en.initOptionColumns} data={setup.en.initOptionData} />
 
 :::caution Best Practice
-Call `KlleonChat.init()` only once per SDK instance. Multiple calls are ignored internally but initializing just once helps with clarity and performance.
+It is recommended to call `KlleonChat.init()` only once per SDK instance. The SDK includes internal logic to prevent duplicate initialization, so even if called multiple times, only the first call will take effect. For optimal performance and clear code management, call `init()` only once during application load.
 :::
 
 ### `KlleonChat.destroy()`
 
-Cleans up all SDK-related resources such as socket connections, WebRTC streams, and event listeners.
+Cleans up all resources used by the SDK (socket connections, WebRTC connections, event listeners, etc.) and fully shuts down the SDK.
 
-**Example:**
+**Usage Example (Initialization and Cleanup):**
 
-```tsx title="App.tsx (SDK Lifecycle)"
+```tsx title="App.tsx (SDK Lifecycle Management)"
 import { useEffect } from "react";
 
 const App = () => {
   useEffect(() => {
     const init = async () => {
-      await window.KlleonChat.init({
+      const { KlleonChat } = window;
+
+      await KlleonChat.init({
         sdk_key: "YOUR_SDK_KEY",
         avatar_id: "YOUR_AVATAR_ID",
         subtitle_code: "en_us",
@@ -64,13 +66,12 @@ const App = () => {
         user_key: "YOUR_USER_KEY",
       });
     };
-    init();
 
     return () => {
+      // Clean up all KlleonChat SDK resources and shut down.
       window.KlleonChat.destroy();
     };
   }, []);
-
   return (
     <div>
       <avatar-container />
@@ -88,6 +89,10 @@ export default App;
 
 Sends a user-entered text message to the avatar.
 
+- **text** (string, required): The text message to send to the avatar.
+
+**Usage Example:**
+
 ```tsx title="App.tsx (sendTextMessage)"
 import { useRef } from "react";
 
@@ -101,7 +106,6 @@ const App = () => {
       inputRef.current.value = "";
     }
   };
-
   return (
     <div>
       <avatar-container />
@@ -111,31 +115,36 @@ const App = () => {
     </div>
   );
 };
-
-export default App;
 ```
 
 ## Voice Input (STT: Speech-to-Text)
 
-Use `startStt()` to begin voice capture and `endStt()` to stop and convert speech to text for the avatar.
+A feature that converts user voice input to text and sends it to the avatar. Use `startStt()` to begin voice input and `endStt()` to finish and send.
 
 :::info Microphone Permission
-Make sure `enable_microphone: true` is set in the `init()` options and that the browser has permission to access the mic.
+To use voice conversation features, browser microphone permission is required. Setting `enable_microphone: true` (default) in `init()` will prompt the SDK to request microphone access.
 :::
 
 ### `KlleonChat.startStt()` / `KlleonChat.endStt()`
+
+- **`KlleonChat.startStt()`**: Begins collecting voice data through the microphone.
+- **`KlleonChat.endStt()`**: Stops the ongoing voice data collection, converts the collected audio to text, and sends it as a message to the avatar.
+
+**Usage Example:**
 
 ```tsx title="App.tsx (startStt, endStt)"
 import { useRef } from "react";
 
 const App = () => {
+  const recordButtonRef = useRef<HTMLButtonElement>(null);
   const isRecording = useRef(false);
 
   const handleRecord = () => {
     if (!isRecording.current) {
       window.KlleonChat.startStt();
       isRecording.current = true;
-    } else {
+    }
+    if (isRecording.current) {
       window.KlleonChat.endStt();
       isRecording.current = false;
     }
@@ -144,7 +153,9 @@ const App = () => {
   return (
     <div>
       <avatar-container />
-      <button onClick={handleRecord}>Toggle Recording</button>
+      <button ref={recordButtonRef} onClick={handleRecord}>
+        Start Recording
+      </button>
     </div>
   );
 };
@@ -152,49 +163,128 @@ const App = () => {
 export default App;
 ```
 
+## Avatar Speech Control
+
 ### `KlleonChat.cancelStt()`
 
+Cancels an ongoing voice input (after calling `startStt()`). The cancelled voice data will not be sent to the avatar, and the system returns to a state ready for new voice input. Use this when the user wants to cancel their voice input mid-recording.
+
+**Usage Example:**
+
 ```tsx title="App.tsx (cancelStt)"
+import { useRef } from "react";
+
 const App = () => {
-  const handleCancel = () => {
-    window.KlleonChat.cancelStt();
+  const recordButtonRef = useRef<HTMLButtonElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const isRecording = useRef(false);
+
+  const handleRecord = () => {
+    if (!isRecording.current) {
+      window.KlleonChat.startStt();
+      isRecording.current = true;
+    }
+    if (isRecording.current) {
+      window.KlleonChat.endStt();
+      isRecording.current = false;
+    }
   };
 
-  return <button onClick={handleCancel}>Cancel STT</button>;
+  const handleCancel = () => {
+    window.KlleonChat.cancelStt();
+    isRecording.current = false;
+  };
+
+  return (
+    <div>
+      <avatar-container />
+      <button ref={recordButtonRef} onClick={handleRecord}>
+        Start Recording
+      </button>
+      <button ref={cancelButtonRef} onClick={handleCancel}>
+        Cancel Recording
+      </button>
+    </div>
+  );
 };
+
+export default App;
 ```
 
 ### `KlleonChat.stopSpeech()`
 
+Immediately stops the avatar's current speech (TTS) output.
+
+**Usage Example:**
+
 ```tsx title="App.tsx (stopSpeech)"
+import { useRef } from "react";
+
 const App = () => {
+  const recordButtonRef = useRef<HTMLButtonElement>(null);
+  const stopSpeechButtonRef = useRef<HTMLButtonElement>(null);
+  const isRecording = useRef(false);
+
+  const handleRecord = () => {
+    if (!isRecording.current) {
+      window.KlleonChat.startStt();
+      isRecording.current = true;
+    }
+    if (isRecording.current) {
+      window.KlleonChat.endStt();
+      isRecording.current = false;
+    }
+  };
+
   const handleStopSpeech = () => {
     window.KlleonChat.stopSpeech();
   };
 
-  return <button onClick={handleStopSpeech}>Stop Speech</button>;
+  return (
+    <div>
+      <avatar-container />
+      <button ref={recordButtonRef} onClick={handleRecord}>
+        Start Recording
+      </button>
+      <button ref={stopSpeechButtonRef} onClick={handleStopSpeech}>
+        Stop Speech
+      </button>
+    </div>
+  );
 };
+
+export default App;
 ```
 
 ## Echo Feature
 
 ### `KlleonChat.echo(text)`
 
+Requests the avatar to speak the provided `text` string directly via TTS.
+
+- **text** (string, required): The text message for the avatar to speak.
+
+**Usage Example:**
+
 ```tsx title="App.tsx (echo)"
+import { useRef } from "react";
+
 const App = () => {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleEcho = () => {
+  const handleSend = () => {
     const text = inputRef.current?.value.trim();
     if (text) {
       window.KlleonChat.echo(text);
+      inputRef.current.value = "";
     }
   };
-
   return (
     <div>
-      <input ref={inputRef} placeholder="Enter text to echo" />
-      <button onClick={handleEcho}>Echo</button>
+      <avatar-container />
+      <chat-container />
+      <input ref={inputRef} type="text" placeholder="Enter a message" />
+      <button onClick={handleSend}>Send</button>
     </div>
   );
 };
@@ -202,54 +292,124 @@ const App = () => {
 
 ### `KlleonChat.startAudioEcho(audio)` / `KlleonChat.endAudioEcho()`
 
-```tsx title="App.tsx (startAudioEcho, endAudioEcho)"
-const App = () => {
-  const audioRef = useRef<HTMLTextAreaElement>(null);
+- **`KlleonChat.startAudioEcho(audio)`**: Sends Base64-encoded `audio` string data to the server, requesting the avatar to speak the audio. You must explicitly call `endAudioEcho()` to terminate the session.
+  - `audio` (string, required): Base64-encoded audio data string. (0.1MB limit, must be valid Base64)
+- **`KlleonChat.endAudioEcho()`**: Terminates the audio echo session and sends a signal to the server for smooth video transition.
 
-  const handleAudioEcho = () => {
-    const audio = audioRef.current?.value.trim();
-    if (audio) {
-      window.KlleonChat.startAudioEcho(audio);
-      setTimeout(() => {
-        window.KlleonChat.endAudioEcho();
-      }, 100);
+**Usage Example:**
+
+```tsx title="App.tsx (startAudioEcho, endAudioEcho)"
+import { useRef } from "react";
+
+const App = () => {
+  const audioInputRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleStartAudioEcho = () => {
+    const audioData = audioInputRef.current?.value.trim();
+    if (audioData) {
+      try {
+        window.KlleonChat.startAudioEcho(audioData);
+        console.log("Audio echo started.");
+
+        // Call endAudioEcho immediately after sending audio (recommended)
+        setTimeout(() => {
+          window.KlleonChat.endAudioEcho();
+          console.log("Audio echo ended.");
+        }, 100);
+      } catch (error) {
+        console.error("Failed to start audio echo:", error);
+      }
+    }
+  };
+
+  const handleMultipleAudioEcho = async () => {
+    const audioList = [
+      "base64_audio_data_1",
+      "base64_audio_data_2",
+      "base64_audio_data_3",
+    ];
+
+    try {
+      // Send multiple audio segments consecutively
+      for (const audio of audioList) {
+        await window.KlleonChat.startAudioEcho(audio);
+        console.log("Audio sent:", audio);
+      }
+
+      // Call endAudioEcho only once after the last audio segment
+      window.KlleonChat.endAudioEcho();
+      console.log("All audio echo ended.");
+    } catch (error) {
+      console.error("Audio echo processing failed:", error);
     }
   };
 
   return (
     <div>
-      <textarea ref={audioRef} placeholder="Enter Base64 audio string" />
-      <button onClick={handleAudioEcho}>Play Audio Echo</button>
+      <avatar-container />
+      <chat-container />
+      <textarea
+        ref={audioInputRef}
+        placeholder="Enter Base64 audio data"
+        rows={4}
+        cols={50}
+      />
+      <button onClick={handleStartAudioEcho}>Single Audio Echo</button>
+      <button onClick={handleMultipleAudioEcho}>Multiple Audio Echo</button>
     </div>
   );
 };
+
+export default App;
 ```
 
-:::info Why use `endAudioEcho()`?
-It helps the system transition smoothly from voice playback to idle or next state.
+:::info Role of End Audio Echo
+`endAudioEcho()` is a signal for smooth video transition after audio playback is complete.
+
+**If not called:**
+
+- Abrupt video transitions may occur
+- In some video modes, the avatar may not return to the idle video
+
+**Recommended usage:**
+
+- Call immediately after sending audio (no need to wait for playback to finish)
+- When sending multiple audio segments consecutively, call only once after the last segment
 :::
 
 ## Changing Avatar
 
 ### `KlleonChat.changeAvatar(option)`
 
+Terminates the current SDK session and starts a new session with a new avatar using the specified `option`.
+
+**ChangeAvatarOption:**
+
 <Table
   columns={setup.en.changeAvatarOptionColumns}
   data={setup.en.changeAvatarOptionData}
 />
 
+**Usage Example:**
+
 ```tsx title="App.tsx (changeAvatar)"
 const App = () => {
   const handleChangeAvatar = () => {
     window.KlleonChat.changeAvatar({
-      avatar_id: "NEW_AVATAR_ID",
+      avatar_id: "YOUR_AVATAR_ID",
       subtitle_code: "en_us",
       voice_code: "en_us",
       voice_tts_speech_speed: 1.0,
     });
   };
 
-  return <button onClick={handleChangeAvatar}>Change Avatar</button>;
+  return (
+    <div>
+      <avatar-container />
+      <chat-container />
+      <button onClick={handleChangeAvatar}>Change Avatar</button>
+    </div>
+  );
 };
 ```
 
@@ -257,14 +417,22 @@ const App = () => {
 
 ### `KlleonChat.clearMessageList()`
 
-Clears the SDK’s internal message list (UI only; server data remains).
+Clears the SDK's internal message list state. Primarily used with SDK-provided UI web components like `<chat-container>` to clear displayed messages from the screen. This method does not delete conversation logs from the server — it only resets the client-side UI message array.
+
+**Usage Example:**
 
 ```tsx title="App.tsx (clearMessageList)"
 const App = () => {
-  const handleClear = () => {
+  const handleClearMessageList = () => {
     window.KlleonChat.clearMessageList();
   };
 
-  return <button onClick={handleClear}>Clear Messages</button>;
+  return (
+    <div>
+      <avatar-container />
+      <chat-container />
+      <button onClick={handleClearMessageList}>Clear Message List</button>
+    </div>
+  );
 };
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/03-usage/03-sdk-event.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/03-usage/03-sdk-event.mdx
@@ -164,14 +164,15 @@ flowchart TD
     D -->|fail| I[SOCKET_FAILED]
     D -->|success| E[STREAMING_CONNECTED]
     E -->|fail| J[STREAMING_FAILED]
-    E -->|success| F[VIDEO_LOAD]
+    E -->|success| H[CONNECTED_FINISH]
+    H --> F[VIDEO_LOAD]
     F --> G[VIDEO_CAN_PLAY]
 
     %% Style
     classDef success fill:#d3f9d8,stroke:#3adb76,stroke-width:2px,color:#000;
     classDef failure fill:#ffe3e3,stroke:#ff6b6b,stroke-width:2px,color:#000;
 
-    class D,E,F,G success;
+    class D,E,H,F,G success;
     class C,I,J failure;
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/03-usage/03-sdk-event.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/03-usage/03-sdk-event.mdx
@@ -173,14 +173,15 @@ flowchart TD
     D -->|失敗| I[SOCKET_FAILED]
     D -->|成功| E[STREAMING_CONNECTED]
     E -->|失敗| J[STREAMING_FAILED]
-    E -->|成功| F[VIDEO_LOAD]
+    E -->|成功| H[CONNECTED_FINISH]
+    H --> F[VIDEO_LOAD]
     F --> G[VIDEO_CAN_PLAY]
 
     %% スタイル設定
     classDef success fill:#d3f9d8,stroke:#3adb76,stroke-width:2px,color:#000;
     classDef failure fill:#ffe3e3,stroke:#ff6b6b,stroke-width:2px,color:#000;
 
-    class D,E,F,G success;
+    class D,E,H,F,G success;
     class C,I,J failure;
 ```
 

--- a/src/data/usage.js
+++ b/src/data/usage.js
@@ -237,11 +237,6 @@ export const usage = {
           "SDK가 사용자 음성 입력이 멈춘 것을 감지했을 때 발생합니다.",
       },
       {
-        chatType: "RATE_LIMIT",
-        description:
-          "서버 요청 속도 제한에 도달했을 때 발생합니다. 잠시 후 다시 시도해 주세요.",
-      },
-      {
         chatType: "ACTIVATE_VOICE",
         description:
           "음성 입력이 활성화되었을 때 발생합니다. 이 상태에서는 아바타가 `VIDEO_CAN_PLAY`가 아니어도 채팅 입력이 가능합니다.",
@@ -490,11 +485,6 @@ export const usage = {
           "Occurs when the SDK detects that user voice input has stopped.",
       },
       {
-        chatType: "RATE_LIMIT",
-        description:
-          "Occurs when the server request rate limit is reached. Please try again after a short while.",
-      },
-      {
         chatType: "ACTIVATE_VOICE",
         description:
           "Occurs when voice input is activated. In this state, chat input is available even if the avatar is not in `VIDEO_CAN_PLAY` status.",
@@ -740,11 +730,6 @@ export const usage = {
         chatType: "USER_SPEECH_STOPPED",
         description:
           "SDKがユーザー音声入力が停止したことを検出した時に発生します。",
-      },
-      {
-        chatType: "RATE_LIMIT",
-        description:
-          "サーバーリクエストのレート制限に達した時に発生します。しばらくしてから再度お試しください。",
       },
       {
         chatType: "ACTIVATE_VOICE",

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -34,7 +34,6 @@ enum ResponseChatType {
   START_LONG_WAIT = "START_LONG_WAIT",
   USER_SPEECH_STARTED = "USER_SPEECH_STARTED",
   USER_SPEECH_STOPPED = "USER_SPEECH_STOPPED",
-  RATE_LIMIT = "RATE_LIMIT",
   ACTIVATE_VOICE = "ACTIVATE_VOICE",
 }
 
@@ -84,7 +83,6 @@ export interface KlleonChat {
   changeAvatar: (option: ChangeAvatarOption) => Promise<void>;
   clearMessageList: () => void;
   stopSpeech: () => void;
-  wakeUpAvatar: () => void;
 }
 
 export interface AvatarProps {


### PR DESCRIPTION
## Summary

- Docusaurus 3.9.2 버전업 및 디자인 시스템 리팩토링
- 홈페이지 3섹션(Hero/Feature/CTA) 구조 개편 및 공유 유틸리티 추출
- SDK v1.2.0 소스 대조 기반 문서 동기화
- i18n 번역 파일(en/ja) 동기화 및 flowchart CONNECTED_FINISH 노드 추가
- 영어 getting-started.mdx의 admonition 버그(\:::tip) 수정
- 실험적 기능(wakeUpAvatar, RATE_LIMIT) 문서에서 제거
- llms-full.txt 루트 파일을 영어 버전으로 교체

## Context7 평가

| 항목 | 값 |
|------|-----|
| Benchmark Score | 77.2 / 100 |
| Code Snippets | 185개 |
| Source Reputation | High |

## Test plan

- [x] `npm run typecheck` 통과
- [x] `npm run build` 3개 로케일(ko/en/ja) 성공
- [x] `build/en/llms-full.txt`에서 wakeUpAvatar, RATE_LIMIT 제거 확인
- [x] Context7 쿼리 테스트 (init, STT, status flow) 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)