### PR TITLE
ci: Context7 문서 자동 리프레시 워크플로우 추가

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,0 +1,29 @@
+name: Refresh Context7 Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'i18n/**'
+      - 'src/data/**'
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  refresh-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Refresh Context7 Documentation
+        id: context7
+        uses: rennf93/upsert-context7@v1
+        with:
+          operation: refresh
+          library-name: "/llmstxt/klleon_io_llms-full_txt"
+
+      - name: Show result
+        run: |
+          echo "Success: ${{ steps.context7.outputs.success }}"
+          echo "Status: ${{ steps.context7.outputs.status-code }}"
+          echo "Message: ${{ steps.context7.outputs.message }}"


### PR DESCRIPTION
## Summary

- main 브랜치에 docs/i18n/src/data 변경 push 시 Context7 문서 자동 리프레시
- GitHub Actions 탭에서 수동 트리거도 가능

## Test plan

- [ ] PR 머지 후 Actions 탭에서 워크플로우 수동 실행 테스트
- [ ] Context7에서 최신 문서 쿼리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)