### PR TITLE
fix: Context7 action 버전 수정

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Refresh Context7 Documentation
         id: context7
-        uses: rennf93/upsert-context7@v1
+        uses: rennf93/upsert-context7@1.1
         with:
           operation: refresh
           library-name: "/llmstxt/klleon_io_llms-full_txt"


### PR DESCRIPTION
## Summary

- `rennf93/upsert-context7@v1` → `@1.1` 버전 태그 수정
- v1 태그가 존재하지 않아 워크플로우 실패 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)